### PR TITLE
feat: move api key entry to options

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,6 +13,9 @@
     "action": {
         "default_popup": "popup.html",
         "default_icon": "social-logo.png"
-
+    },
+    "options_ui": {
+        "page": "options.html",
+        "open_in_tab": false
     }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -1,7 +1,27 @@
 <!doctype html>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-<title>Deepgram Transcript and Translation Options</title>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <title>Deepgram Transcript and Translation Options</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        .password-control {
+            position: relative;
+        }
+        .password-control-toggle {
+            position: relative;
+            left: -25px;
+        }
+        .options-save-message {
+            display: none;
+        }
+        .options-save-message--active {
+            display: block;
+        }
+    </style>
+</head>
+<body>
 <form id="options-form">
     <h1>About</h1>
 	<p>
@@ -12,15 +32,17 @@
 
 	<hr>
 
-        <h1>Get started</h1>
-        <p>
-		<label>
-			<strong>🔑 Deepgram API key</strong> 
-			<input type="text" name="apiKey" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
-			<span id="validation"></span>
-		</label>
-        <small>If you don't have an API key, you can find one <a id="get-API-key" href="https://console.deepgram.com/signup?jump=keys">here</a></small>
-    </p> 
-
+    <h1>Get started</h1>
+    <div class="password-control">
+        <label><strong>🔑 Deepgram API key</strong></label>
+        <input id="apiKey" class="password-control-input" type="password" name="apiKey" placeholder="" spellcheck="false" autocomplete="off" autocapitalize="off" required>
+        <i id="passwordToggle" class="password-control-toggle fa-regular fa-eye-slash"></i>
+        <span id="validation"></span>
+    </div>
+    <p><small>If you don't have an API key, you can find one <a id="get-API-key" href="https://console.deepgram.com/signup?jump=keys">here</a></small></p>
+    <button id="optionsSave" type="submit">Save</button>
+    <div class="options-save-message"><p><strong>Your settings have been saved.</strong></p></div>
 </form>
-<!-- <script src="options.ts"></script> -->
+<script src="options.ts" type="module"></script>
+</body>
+</html>

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,54 @@
+const cssSelectors: Readonly<Record<string, string>> = {
+    keyInput: '#apiKey',
+    keyToggle: '#passwordToggle',
+    save: '#optionsSave',
+    saveMessage: '.options-save-message'
+}
+const cssClasses: Readonly<Record<string, string>> = {
+    keyVisible: 'fa-eye',
+    messageActive: 'options-save-message--active'
+}
+
+const apiKeyInput = document.querySelector(cssSelectors.keyInput) as HTMLInputElement | null
+const apiKeyToggle = document.querySelector(cssSelectors.keyToggle) as HTMLElement | null
+const saveTrigger = document.querySelector(cssSelectors.save) as HTMLElement | null
+const saveMessage = document.querySelector(cssSelectors.saveMessage) as HTMLElement | null
+
+loadOptions()
+
+apiKeyToggle?.addEventListener('click', () => toggleApiKeyVisibility())
+saveTrigger?.addEventListener('click', (event) => {
+    event.preventDefault()
+    saveOptions()
+})
+
+apiKeyInput?.addEventListener('focus', () => hideSaveMessage())
+
+function loadOptions() {
+    chrome.storage.local.get('key').then(({ key }) => {
+        if (apiKeyInput) {
+            apiKeyInput.value = key
+        }
+    })
+}
+
+function saveOptions() {
+    const apiKey: string | undefined = apiKeyInput?.value
+    if (apiKeyInput && apiKeyInput.value) {
+        chrome.storage.local.set({ 'key': apiKeyInput.value })
+            .then(() => showSaveMessage())
+    }
+}
+
+function showSaveMessage() {
+    saveMessage?.classList.add(cssClasses.messageActive)
+}
+function hideSaveMessage() {
+    saveMessage?.classList.remove(cssClasses.messageActive)
+}
+
+function toggleApiKeyVisibility()  {
+    const type = apiKeyInput?.getAttribute('type') === 'password' ? 'text' : 'password'
+    apiKeyInput?.setAttribute('type', type)
+    apiKeyToggle?.classList.toggle(cssClasses.keyVisible)
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -52,7 +52,7 @@
     <div class="controls">
         <div class="text-control">
             <label class="text-control-label" for="api-key">API Key</label>
-            <input class="text-control-input" type="password" name="api-key" required id="api-key">
+            <input class="text-control-input" type="password" name="api-key" required disabled id="api-key">
             <i id="togglePassword" class="fa-regular fa-eye-slash"></i>
         </div>
         <div class="button-controls">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,15 +1,9 @@
 import { content } from './content-script';
 
+loadApiKey()
 showLatestTranscript()
 
 document.getElementById('start')?.addEventListener('click', async () => {
-    const api = document.getElementById('api-key') as HTMLInputElement | null
-
-    const key = api?.value
-
-      chrome.storage.local.set({ key }, () => {
-        alert('Deepgram API Key Set')
-      })
     const tab = await getCurrentTab()
     if(!tab) return alert('Require an active tab')
     chrome.scripting.executeScript({
@@ -29,6 +23,15 @@ chrome.runtime.onMessage.addListener(({ message }) => {
         showLatestTranscript()
     }
 })
+
+function loadApiKey() {
+    chrome.storage.local.get('key').then(({ key }) => {
+        const apiKeyElem = document.getElementById('api-key') as HTMLInputElement | null
+        if (apiKeyElem) {
+            apiKeyElem.value = key
+        }
+    })
+}
 
 function showLatestTranscript() {
     chrome.storage.local.get("transcript", ({ transcript }) => {


### PR DESCRIPTION
## Proposed changes

This PR resolves GH-15 (add logic in options.ts to handle API key submission)

### Popup
* Disabled API key input
* Removed "API key set" alert from "Start Transcription" button

### Options
* Added Save button
* Set save button to store API key
* Added success message

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Refactors I made during the code move:
* reduced magic strings (e.g. css selectors for html elements) by assigning them to `Readonly<Record>`s
* reduced repeat `document.query` method calls by assigning them to variables
* abstracted event callbacks into named functions to make code more self-documenting.
